### PR TITLE
Fix links on Upgraded-to-Gatsby-v2 post

### DIFF
--- a/src/pages/articles/2018-10-18---Upgraded-to-Gatsby-v2/index.md
+++ b/src/pages/articles/2018-10-18---Upgraded-to-Gatsby-v2/index.md
@@ -17,16 +17,16 @@ by the folks at [Gatsby Central](https://www.gatsbycentral.com/).
 
 Here's a little recommended reading for Gatsby v2.
 
-* First, [what's new in v2](/whats-new-in-gatsby-v2)
-* Next, [when should I upgrade?](/when-should-i-upgrade-to-gatsby-v2)
+* First, [what's new in v2](https://www.gatsbycentral.com/whats-new-in-gatsby-v2)
+* Next, [when should I upgrade?](https://www.gatsbycentral.com/when-should-i-upgrade-to-gatsby-v2)
 
 If you **do decide to upgrade**, these articles will help you do that.
 
-* [Getting started with Gatsby v2](/getting-started-with-gatsby-v2)
-* [Should I rebuild my site for Gatsby v2?](/should-i-rebuild-my-site-for-gatsby-v2)
-* [How do layouts work in Gatsby v2](/how-do-layouts-work-in-gatsby-v2)
-* [StaticQuery in Gatsby v2](/staticquery-in-gatsby-v2)
+* [Getting started with Gatsby v2](https://www.gatsbycentral.com/getting-started-with-gatsby-v2)
+* [Should I rebuild my site for Gatsby v2?](https://www.gatsbycentral.com/should-i-rebuild-my-site-for-gatsby-v2)
+* [How do layouts work in Gatsby v2](https://www.gatsbycentral.com/how-do-layouts-work-in-gatsby-v2)
+* [StaticQuery in Gatsby v2](https://www.gatsbycentral.com/staticquery-in-gatsby-v2)
 
 Finally, here's a cheat sheet we prepared to help during the upgrade:
 
-* [Gatsby v2 refactoring cheat sheet](/gatsby-v2-refactoring-cheat-sheet)
+* [Gatsby v2 refactoring cheat sheet](https://www.gatsbycentral.com/gatsby-v2-refactoring-cheat-sheet)


### PR DESCRIPTION
The links on src/pages/articles/2018-10-18---Upgraded-to-Gatsby-v2/index.md were relative to https://www.gatsbycentral.com/. This adds the domain to fix the links.