### PR TITLE
Bring code and .eslintrc in line

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,16 +1,16 @@
 {
   "parser": "babel-eslint",
   "extends": "airbnb",
-  "plugins": [
-    "import",
-    "jsx-a11y",
-    "react"
-  ],
+  "plugins": ["import", "jsx-a11y", "react"],
   "globals": {
     "graphql": true
   },
   "rules": {
-    "arrow-body-style": ["error", "as-needed", { "requireReturnForObjectLiteral": true }],
+    "arrow-body-style": [
+      "error",
+      "as-needed",
+      { "requireReturnForObjectLiteral": true }
+    ],
     "arrow-parens": ["error", "as-needed"],
     "comma-dangle": ["error", "always-multiline"],
     "function-paren-newline": ["error", "consistent"],

--- a/.eslintrc
+++ b/.eslintrc
@@ -15,13 +15,13 @@
     "comma-dangle": ["error", "always-multiline"],
     "function-paren-newline": "off",
     "no-console": "off",
-    "prefer-destructuring": ["off"],
+    "prefer-destructuring": "off",
     "semi": ["error", "never"],
-    "import/extensions": ["off"],
-    "import/no-extraneous-dependencies": ["off"],
-    "jsx-a11y/anchor-is-valid": ["off"],
-    "react/jsx-filename-extension": ["off"],
-    "react/prefer-stateless-function": ["off"],
-    "react/prop-types": ["off"]
+    "import/extensions": "off",
+    "import/no-extraneous-dependencies": "off",
+    "jsx-a11y/anchor-is-valid": "off",
+    "react/jsx-filename-extension": "off",
+    "react/prefer-stateless-function": "off",
+    "react/prop-types": "off"
   }
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -13,7 +13,7 @@
     ],
     "arrow-parens": ["error", "as-needed"],
     "comma-dangle": ["error", "always-multiline"],
-    "function-paren-newline": ["error", "consistent"],
+    "function-paren-newline": "off",
     "no-console": "off",
     "prefer-destructuring": ["off"],
     "semi": ["error", "never"],

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,25 +1,27 @@
 {
-    "parser": "babel-eslint",
-    "extends": "airbnb",
-    "plugins": [
-        "react",
-        "jsx-a11y",
-        "import"
-    ],
-    "globals": {
-        "graphql": true
-    },
-    "rules": {
-        "react/jsx-filename-extension": [0],
-        "react/prefer-stateless-function": [0],
-        "react/prop-types": [0],
-        "import/no-extraneous-dependencies": [0],
-        "comma-dangle": ["error", "never"],
-        "jsx-a11y/anchor-is-valid": [0],
-        "prefer-destructuring": [0],
-        "object-curly-newline": ["error", { "multiline": true, "minProperties": 5 }],
-        "arrow-body-style": ["error", "as-needed", { "requireReturnForObjectLiteral": true }],
-        "import/extensions": [0],
-        "no-console": "off"
-    }
+  "parser": "babel-eslint",
+  "extends": "airbnb",
+  "plugins": [
+    "import",
+    "jsx-a11y",
+    "react"
+  ],
+  "globals": {
+    "graphql": true
+  },
+  "rules": {
+    "arrow-body-style": ["error", "as-needed", { "requireReturnForObjectLiteral": true }],
+    "arrow-parens": ["error", "as-needed"],
+    "comma-dangle": ["error", "always-multiline"],
+    "function-paren-newline": ["error", "consistent"],
+    "no-console": "off",
+    "prefer-destructuring": ["off"],
+    "semi": ["error", "never"],
+    "import/extensions": ["off"],
+    "import/no-extraneous-dependencies": ["off"],
+    "jsx-a11y/anchor-is-valid": ["off"],
+    "react/jsx-filename-extension": ["off"],
+    "react/prefer-stateless-function": ["off"],
+    "react/prop-types": ["off"]
+  }
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,6 @@
 {
   "parser": "babel-eslint",
-  "extends": "airbnb",
+  "extends": ["prettier", "airbnb"],
   "plugins": ["import", "jsx-a11y", "react"],
   "globals": {
     "graphql": true

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -65,8 +65,7 @@ module.exports = {
                   url: site.siteMetadata.site_url + edge.node.fields.slug,
                   guid: site.siteMetadata.site_url + edge.node.fields.slug,
                   custom_elements: [{ 'content:encoded': edge.node.html }],
-                })
-              ),
+                })),
             query: `
               {
                 allMarkdownRemark(
@@ -124,9 +123,9 @@ module.exports = {
       options: { trackingId: 'UA-73379983-2' },
     },
     {
-      resolve: `gatsby-plugin-google-fonts`,
+      resolve: 'gatsby-plugin-google-fonts',
       options: {
-        fonts: [`roboto\:400,400i,500,700`],
+        fonts: ['roboto:400,400i,500,700'],
       },
     },
     {
@@ -166,7 +165,7 @@ module.exports = {
     'gatsby-plugin-catch-links',
     'gatsby-plugin-react-helmet',
     {
-      resolve: `gatsby-plugin-sass`,
+      resolve: 'gatsby-plugin-sass',
       options: {
         postCssPlugins: [
           lost(),

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -65,7 +65,8 @@ module.exports = {
                   url: site.siteMetadata.site_url + edge.node.fields.slug,
                   guid: site.siteMetadata.site_url + edge.node.fields.slug,
                   custom_elements: [{ 'content:encoded': edge.node.html }],
-                })),
+                })
+              ),
             query: `
               {
                 allMarkdownRemark(

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "babel-eslint": "^8.2.1",
     "eslint": "^4.14.0",
     "eslint-config-airbnb": "^16.1.0",
+    "eslint-config-prettier": "^3.1.0",
     "eslint-plugin-import": "^2.8.0",
     "eslint-plugin-jsx-a11y": "^6.0.3",
     "eslint-plugin-react": "^7.5.1",

--- a/src/components/Links/index.jsx
+++ b/src/components/Links/index.jsx
@@ -21,17 +21,26 @@ class Links extends React.Component {
             <a
               href={`https://www.twitter.com/${links.twitter}`}
               target="_blank"
+              rel="noopener noreferrer"
             >
               <i className="icon-twitter" />
             </a>
           </li>
           <li className="links__list-item">
-            <a href={`https://www.github.com/${links.github}`} target="_blank">
+            <a
+              href={`https://www.github.com/${links.github}`}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
               <i className="icon-github" />
             </a>
           </li>
           <li className="links__list-item">
-            <a href={`https://www.vk.com/${links.vk}`} target="_blank">
+            <a
+              href={`https://www.vk.com/${links.vk}`}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
               <i className="icon-vkontakte" />
             </a>
           </li>

--- a/src/components/PageTemplateDetails/index.jsx
+++ b/src/components/PageTemplateDetails/index.jsx
@@ -15,6 +15,7 @@ class PageTemplateDetails extends React.Component {
               <h1 className="page__title">{page.frontmatter.title}</h1>
               <div
                 className="page__body"
+                /* eslint-disable-next-line react/no-danger */
                 dangerouslySetInnerHTML={{ __html: page.html }}
               />
             </div>

--- a/src/components/PostTemplateDetails/index.jsx
+++ b/src/components/PostTemplateDetails/index.jsx
@@ -50,6 +50,7 @@ class PostTemplateDetails extends React.Component {
             <h1 className="post-single__title">{post.frontmatter.title}</h1>
             <div
               className="post-single__body"
+              /* eslint-disable-next-line react/no-danger */
               dangerouslySetInnerHTML={{ __html: post.html }}
             />
             <div className="post-single__date">

--- a/src/pages/categories.jsx
+++ b/src/pages/categories.jsx
@@ -1,8 +1,8 @@
+import kebabCase from 'lodash/kebabCase'
 import React from 'react'
 import { Link, graphql } from 'gatsby'
 import Helmet from 'react-helmet'
 import Layout from '../components/Layout'
-import kebabCase from 'lodash/kebabCase'
 import Sidebar from '../components/Sidebar'
 
 class CategoriesRoute extends React.Component {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4277,6 +4277,13 @@ eslint-config-airbnb@^16.1.0:
   dependencies:
     eslint-config-airbnb-base "^12.1.0"
 
+eslint-config-prettier@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-3.1.0.tgz#2c26d2cdcfa3a05f0642cd7e6e4ef3316cdabfa2"
+  integrity sha512-QYGfmzuc4q4J6XIhlp8vRKdI/fI0tQfQPy1dME3UOLprE+v4ssH/3W9LM2Q7h5qBcy5m0ehCrBDU2YF8q6OY8w==
+  dependencies:
+    get-stdin "^6.0.0"
+
 eslint-config-react-app@3.0.0-next.66cc7a90:
   version "3.0.0-next.66cc7a90"
   resolved "https://registry.yarnpkg.com/eslint-config-react-app/-/eslint-config-react-app-3.0.0-next.66cc7a90.tgz#f8c7bb3cca0f1e8f60bbf567ec71f6af1cce7edd"
@@ -5681,6 +5688,11 @@ get-stdin@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-4.0.1.tgz#b968c6b0a04384324902e8bf1a5df32579a450fe"
   integrity sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=
+
+get-stdin@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-6.0.0.tgz#9e09bf712b360ab9225e812048f71fde9c89657b"
+  integrity sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==
 
 get-stream@^2.2.0:
   version "2.3.1"


### PR DESCRIPTION
The .eslintrc rules did not match the style of the code. This change applies the existing rules for one-off cases, and changes the rules to match the code in cases where the code largely deviates from them anyway. In particular, in line with `react/jsx-no-target-blank`, it adds `rel="noopener noreferrer"` [as necessary](https://mathiasbynens.github.io/rel-noopener/).

.eslintrc is also formatted for readability. Of note, each instance of `[0]` is changed to `["off"]` for clarity of purpose.

I am unsure how to handle the ESLint warning `ESLint: Dangerous property 'dangerouslySetInnerHTML' found (react/no-danger)` for the two instances of in `src/components/[Page, Post]TemplateDetails/index.js`.

