### PR TITLE
Fix: pass slug in the fields

### DIFF
--- a/src/templates/post-template.jsx
+++ b/src/templates/post-template.jsx
@@ -47,6 +47,7 @@ export const pageQuery = graphql`
       html
       fields {
         tagSlugs
+        slug
       }
       frontmatter {
         title


### PR DESCRIPTION
This allows Disqus.jsx to correctly render comments page.

Without the change, `postNode.fields.slug` is null.